### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/delinea/secrets/server.py
+++ b/delinea/secrets/server.py
@@ -167,7 +167,7 @@ class PasswordGrantAuthorizer(Authorizer):
                 other than a valid Access Grant
         """
 
-        response = requests.post(token_url, grant_request)
+        response = requests.post(token_url, grant_request, timeout=60)
 
         try:  # TSS returns a 200 (OK) containing HTML for some error conditions
             return json.loads(SecretServer.process(response).content)
@@ -301,14 +301,14 @@ class SecretServer:
         endpoint_url = f"{self.api_url}/secrets/{id}"
 
         if query_params is None:
-            return self.process(requests.get(endpoint_url, headers=self.headers())).text
+            return self.process(requests.get(endpoint_url, headers=self.headers(), timeout=60)).text
         else:
             return self.process(
                 requests.get(
                     endpoint_url,
                     params=query_params,
                     headers=self.headers(),
-                )
+                timeout=60)
             ).text
 
     def get_secret(self, id, fetch_file_attachments=True, query_params=None):
@@ -343,7 +343,7 @@ class SecretServer:
                     endpoint_url = f"{self.api_url}/secrets/{id}/fields/{item['slug']}"
                     if query_params is None:
                         item["itemValue"] = self.process(
-                            requests.get(endpoint_url, headers=self.headers())
+                            requests.get(endpoint_url, headers=self.headers(), timeout=60)
                         )
                     else:
                         item["itemValue"] = self.process(
@@ -351,7 +351,7 @@ class SecretServer:
                                 endpoint_url,
                                 params=query_params,
                                 headers=self.headers(),
-                            )
+                            timeout=60)
                         )
         return secret
 
@@ -391,14 +391,14 @@ class SecretServer:
         endpoint_url = f"{self.api_url}/secrets"
 
         if query_params is None:
-            return self.process(requests.get(endpoint_url, headers=self.headers())).text
+            return self.process(requests.get(endpoint_url, headers=self.headers(), timeout=60)).text
         else:
             return self.process(
                 requests.get(
                     endpoint_url,
                     params=query_params,
                     headers=self.headers(),
-                )
+                timeout=60)
             ).text
 
     def get_secret_ids_by_folderid(self, folder_id):
@@ -417,7 +417,7 @@ class SecretServer:
         params = {"filter.folderId": folder_id}
         endpoint_url = f"{self.api_url}/secrets/search-total"
         params["take"] = self.process(
-            requests.get(endpoint_url, params=params, headers=self.headers())
+            requests.get(endpoint_url, params=params, headers=self.headers(), timeout=60)
         ).text
         response = self.search_secrets(query_params=params)
 


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fpython-tss-sdk%7C319db5b2747843d2cb88c3bc513067490d2b46f4)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->