### PR TITLE
fix(build): support flit-core 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,25 @@
 [build-system]
-requires = ["flit_core ==3.12.0"]
+requires = ["flit_core >=3.12,<5"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "delinea"
-author = "Delinea Integrations"
-author-email = "GitHub@delinea.com"
+[project]
+name = "python-tss-sdk"
+authors = [{name = "Delinea Integrations", email = "GitHub@delinea.com"}]
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.8"
+dynamic = ["version", "description"]
+dependencies = ["requests >= 2.12.5"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11"
 ]
-description-file = "README.md"
-requires = [
-    "requests >= 2.12.5"
-]
-requires-python=">=3.8"
-dist-name = "python-tss-sdk"
+
+[project.urls]
+Homepage = "https://github.com/DelineaXPM/python-tss-sdk"
+
+[tool.flit.module]
+name = "delinea"


### PR DESCRIPTION
flit-core 4 removed the old `[tool.flit.metadata]` table, so the build failed with the pinned `flit_core ==3.12.0` lifted to 4.x.

Migrate the metadata to the PEP 621 `[project]` table:

- widen the build requirement to `flit_core >=3.12,<5`
- move `module` to `[tool.flit.module]`
- take `version` and `description` from the package docstring and `__version__` via `dynamic`
- declare the license as the SPDX expression `Apache-2.0` and drop the now-conflicting `License :: OSI Approved` classifier
- add a `Homepage` project URL

Verified `python -m build` produces an sdist and a wheel with correct metadata under both flit-core 4.0.2 and 3.12.0.

Docs:

- https://flit.pypa.io/en/stable/history.html#version-4-0
- https://flit.pypa.io/en/stable/pyproject_toml.html#pyproject-toml-project